### PR TITLE
Adds `mac2-m2` type trigger

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -103,6 +103,7 @@ Resources:
               InstanceType:
                 - mac1.metal
                 - mac2.metal
+                - mac2-m2.metal
           responseElements:
             AllocateHostsResponse:
               hostIdSet:


### PR DESCRIPTION
Supports the new M2 Pro instance types (https://aws.amazon.com/blogs/aws/new-amazon-ec2-m2-pro-mac-instances-built-on-apple-silicon-m2-pro-mac-mini-computers/)