### PR TITLE
Adds missed `mac2-m2pro.metal` type

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -104,6 +104,7 @@ Resources:
                 - mac1.metal
                 - mac2.metal
                 - mac2-m2.metal
+                - mac2-m2pro.metal
           responseElements:
             AllocateHostsResponse:
               hostIdSet:


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html